### PR TITLE
Some optimisations...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SDCCOPTS ?= --iram-size 256 --code-size 4089 --xram-size 0
+SDCCOPTS ?= --iram-size 256 --code-size 4089 --xram-size 0 --data-loc 0x30
 STCGAL ?= stcgal/stcgal.py
 STCGALOPTS ?= 
 STCGALPORT ?= /dev/ttyUSB0

--- a/src/ds1302.h
+++ b/src/ds1302.h
@@ -48,14 +48,14 @@ typedef struct ds1302_rtc {
     
     union {
         struct {
-            // 1-12
+            // 0-23
             uint8_t hour:4;         
             uint8_t tenhour:2;       
             uint8_t reserved2a:1;
             uint8_t hour_12_24:1;    // 0=24h
         } h24;
         struct {
-            // 0-23
+            // 1-12
             uint8_t hour:4;      
             uint8_t tenhour:1;
             uint8_t pm:1;           // 0=am, 1=pm;
@@ -108,6 +108,9 @@ typedef struct ram_config {
     uint8_t   reserved3:3;
 };
 
+struct ds1302_rtc __at (0x24) rtc;
+struct ram_config __at (0x2c) config;
+
 void ds_ram_config_init(uint8_t config[4]);
 
 void ds_ram_config_write(uint8_t config[4]);
@@ -133,21 +136,21 @@ void ds_init();
 void ds_reset_clock();
 
 // toggle 12/24 hour mode
-void ds_hours_12_24_toggle(struct ds1302_rtc* rtc);
+void ds_hours_12_24_toggle();
     
 // increment hours
-void ds_hours_incr(struct ds1302_rtc* rtc);
+void ds_hours_incr();
 
 // increment minutes
-void ds_minutes_incr(struct ds1302_rtc* rtc);
+void ds_minutes_incr();
 
 // increment month
-void ds_month_incr(struct ds1302_rtc* rtc);
+void ds_month_incr();
 
 // increment day
-void ds_day_incr(struct ds1302_rtc* rtc);
+void ds_day_incr();
 
-void ds_weekday_incr(struct ds1302_rtc* rtc);
+void ds_weekday_incr();
     
 // split bcd to int
 uint8_t ds_split2int(uint8_t tens, uint8_t ones);

--- a/src/led.c
+++ b/src/led.c
@@ -27,7 +27,9 @@ const uint8_t ledtable[] = {
     0b10000000, // 0x13 - '.'
 };
 
-void filldisplay (uint8_t dbuf[4], uint8_t pos, uint8_t val, __bit dp) __critical {
+extern uint8_t dbuf[4];
+
+void filldisplay (uint8_t pos, uint8_t val, __bit dp) __critical {
     // store display bytes
     // logic is inverted due to bjt pnp drive, i.e. low = on, high = off
     dbuf[pos] = ~(dp << 7 | ledtable[val]);

--- a/src/led.h
+++ b/src/led.h
@@ -15,4 +15,4 @@
 #define LED_h   0x12
 #define LED_dp  0x13
 
-void filldisplay(uint8_t dbuf[4], uint8_t pos, uint8_t val, __bit dp);
+void filldisplay(uint8_t pos, uint8_t val, __bit dp);

--- a/src/main.c
+++ b/src/main.c
@@ -76,9 +76,6 @@ uint16_t temp;    // temperature sensor value
 uint8_t lightval;   // light sensor value
 __bit  beep = 1;
 
-struct ds1302_rtc rtc;
-struct ram_config config;
-
 volatile uint8_t displaycounter;
 uint8_t dbuf[4];     // led display buffer
 uint8_t dmode = M_NORMAL;   // display mode state
@@ -224,7 +221,7 @@ int main()
               flash_hours = !flash_hours;
               if (! flash_hours) {
                   if (getkeypress(S2)) {
-                      ds_hours_incr(&rtc);
+                      ds_hours_incr();
                   }
                   if (getkeypress(S1))
                       dmode = M_SET_MINUTE;
@@ -236,7 +233,7 @@ int main()
               flash_minutes = !flash_minutes;
               if (! flash_minutes) {
                   if (getkeypress(S2)) {
-                      ds_minutes_incr(&rtc);
+                      ds_minutes_incr();
                   }
                   if (getkeypress(S1))
                       dmode = M_SET_HOUR_12_24;
@@ -245,7 +242,7 @@ int main()
 
           case M_SET_HOUR_12_24:
               if (getkeypress(S2))
-                  ds_hours_12_24_toggle(&rtc);
+                  ds_hours_12_24_toggle();
               if (getkeypress(S1))
                   dmode = M_NORMAL;
               break;
@@ -268,7 +265,7 @@ int main()
               flash_month = !flash_month;
               if (! flash_month) {
                   if (getkeypress(S2)) {
-                      ds_month_incr(&rtc);
+                      ds_month_incr();
                   }
                   if (getkeypress(S1)) {
                       flash_month = 0;
@@ -281,7 +278,7 @@ int main()
               flash_day = !flash_day;
               if (! flash_day) {
                   if (getkeypress(S2)) {
-                      ds_day_incr(&rtc);
+                      ds_day_incr();
                   }
                   if (getkeypress(S1)) {
                       flash_day = 0;
@@ -292,7 +289,7 @@ int main()
               
           case M_WEEKDAY_DISP:
               if (getkeypress(S1))
-                  ds_weekday_incr(&rtc);
+                  ds_weekday_incr();
               if (getkeypress(S2))
                   dmode = M_NORMAL;
               break;
@@ -325,69 +322,69 @@ int main()
           case M_SET_HOUR:
           case M_SET_MINUTE:
               if (flash_hours) {
-                  filldisplay(dbuf, 0, LED_BLANK, 0);
-                  filldisplay(dbuf, 1, LED_BLANK, display_colon);
+                  filldisplay( 0, LED_BLANK, 0);
+                  filldisplay( 1, LED_BLANK, display_colon);
               } else {
                   if (rtc.h24.hour_12_24 == HOUR_24) {
-                      filldisplay(dbuf, 0, rtc.h24.tenhour, 0);
+                      filldisplay( 0, rtc.h24.tenhour, 0);
                   } else {
-                      filldisplay(dbuf, 0, rtc.h12.tenhour ? rtc.h12.tenhour : LED_BLANK, 0);
+                      filldisplay( 0, rtc.h12.tenhour ? rtc.h12.tenhour : LED_BLANK, 0);
                   }                  
-                  filldisplay(dbuf, 1, rtc.h12.hour, display_colon);      
+                  filldisplay( 1, rtc.h12.hour, display_colon);      
               }
   
               if (flash_minutes) {
-                  filldisplay(dbuf, 2, LED_BLANK, display_colon);
-                  filldisplay(dbuf, 3, LED_BLANK, (rtc.h12.hour_12_24) ? rtc.h12.pm : 0);  
+                  filldisplay( 2, LED_BLANK, display_colon);
+                  filldisplay( 3, LED_BLANK, (rtc.h12.hour_12_24) ? rtc.h12.pm : 0);  
               } else {
-                  filldisplay(dbuf, 2, rtc.tenminutes, display_colon);
-                  filldisplay(dbuf, 3, rtc.minutes, (rtc.h12.hour_12_24) ? rtc.h12.pm : 0);  
+                  filldisplay( 2, rtc.tenminutes, display_colon);
+                  filldisplay( 3, rtc.minutes, (rtc.h12.hour_12_24) ? rtc.h12.pm : 0);  
               }
               break;
 
           case M_SET_HOUR_12_24:
-              filldisplay(dbuf, 0, LED_BLANK, 0);
+              filldisplay( 0, LED_BLANK, 0);
               if (rtc.h24.hour_12_24 == HOUR_24) {
-                  filldisplay(dbuf, 1, 2, 0);
-                  filldisplay(dbuf, 2, 4, 0);
+                  filldisplay( 1, 2, 0);
+                  filldisplay( 2, 4, 0);
               } else {
-                  filldisplay(dbuf, 1, 1, 0);
-                  filldisplay(dbuf, 2, 2, 0);                  
+                  filldisplay( 1, 1, 0);
+                  filldisplay( 2, 2, 0);                  
               }
-              filldisplay(dbuf, 3, LED_h, 0);
+              filldisplay( 3, LED_h, 0);
               break;
               
           case M_DATE_DISP:
           case M_SET_MONTH:
           case M_SET_DAY:
               if (flash_month) {
-                  filldisplay(dbuf, 0, LED_BLANK, 0);
-                  filldisplay(dbuf, 1, LED_BLANK, 1);
+                  filldisplay( 0, LED_BLANK, 0);
+                  filldisplay( 1, LED_BLANK, 1);
               } else {
-                  filldisplay(dbuf, 0, rtc.tenmonth, 0);
-                  filldisplay(dbuf, 1, rtc.month, 1);          
+                  filldisplay( 0, rtc.tenmonth, 0);
+                  filldisplay( 1, rtc.month, 1);          
               }
               if (flash_day) {
-                  filldisplay(dbuf, 2, LED_BLANK, 0);
-                  filldisplay(dbuf, 3, LED_BLANK, 0);              
+                  filldisplay( 2, LED_BLANK, 0);
+                  filldisplay( 3, LED_BLANK, 0);              
               } else {
-                  filldisplay(dbuf, 2, rtc.tenday, 0);
-                  filldisplay(dbuf, 3, rtc.day, 0);              
+                  filldisplay( 2, rtc.tenday, 0);
+                  filldisplay( 3, rtc.day, 0);              
               }     
               break;
                    
           case M_WEEKDAY_DISP:
-              filldisplay(dbuf, 0, LED_BLANK, 0);
-              filldisplay(dbuf, 1, LED_DASH, 0);
-              filldisplay(dbuf, 2, rtc.weekday, 0);
-              filldisplay(dbuf, 3, LED_DASH, 0);
+              filldisplay( 0, LED_BLANK, 0);
+              filldisplay( 1, LED_DASH, 0);
+              filldisplay( 2, rtc.weekday, 0);
+              filldisplay( 3, LED_DASH, 0);
               break;
               
           case M_TEMP_DISP:
-              filldisplay(dbuf, 0, ds_int2bcd_tens(temp), 0);
-              filldisplay(dbuf, 1, ds_int2bcd_ones(temp), 0);
-              filldisplay(dbuf, 2, config.temp_C_F == 0 ? LED_c : LED_f, 1);
-              filldisplay(dbuf, 3, (temp > 0) ? LED_BLANK : LED_DASH, 0);  
+              filldisplay( 0, ds_int2bcd_tens(temp), 0);
+              filldisplay( 1, ds_int2bcd_ones(temp), 0);
+              filldisplay( 2, config.temp_C_F == 0 ? LED_c : LED_f, 1);
+              filldisplay( 3, (temp > 0) ? LED_BLANK : LED_DASH, 0);  
               break;                  
       }
                   


### PR DESCRIPTION
Hi,

I just discovered your code after buying a DIY STC clock too... Surprise, it was using a STC15, which I long time ago already used (since I am the guy who did the tests with the STC15+NRF24L01 modules on jjmz.free.fr...).

So I tested your code, and it is just great - when I will have more time, I will try to modify it to display day-of-week as text, and perhaps some more other things.

I noticed that you were perhaps short on memory to try more things, so here are some modifications you could pick to save some memory : use 'callee_saves' for functions that are not modifying lots of registers, don't use struct as function parameters - it generates quite long 8051 code. 

I have not finished with the 'rtc' and 'config' structs at fixed memory location, but since those are using bit fileds, it could take advantage of the 0x20-0x3F memory range of the 8051 that is also accessible as bits.

JJ

PS: I wasn't aware of the stcgal project to program the STC from Linux. I learnt about it though your project. With it, I will perhaps continue my tests on the STC15LC204+NRF modules... Thanks.