### PR TITLE
Use sdcc from PATH again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SDCC ?= /usr/local/bin/sdcc
+SDCC ?= sdcc
 SDCCOPTS ?= --iram-size 256 --code-size 4089 --xram-size 0 --data-loc 0x30 --disable-warning 126 --disable-warning 59
 STCGAL ?= stcgal/stcgal.py
 STCGALOPTS ?= 


### PR DESCRIPTION
The docs say sdcc needs to be installed in the path, but a previous patch moved the default search to be in /usr/local/bin. This puts it back.