### PR TITLE
Don't overflow the 8 bit counter for deciseconds.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -430,6 +430,8 @@ int main()
       ds_ram_config_write(); 
       _delay_ms(40);
       count++;
+      if (count > 200)
+        count -= 200;
       WDT_CLEAR();
     }
 }


### PR DESCRIPTION
This prevents a stutter of the seconds-colon every 25.6 seconds.