### PR TITLE
rough static time correction

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -155,6 +155,16 @@ uint8_t snooze_time;	//snooze(min)
 uint8_t alarm_mm_snooze;	//next alarm time (min)
 uint8_t ss;
 
+#if defined(WITH_MONTHLY_CORR) && WITH_MONTHLY_CORR != 0
+#define SEC_PER_MONTH 2592000
+#if WITH_MONTHLY_CORR > 0
+#define CORR_VALUE 1 // +1 sec every ~RUNTIME_PER_SEC seconds
+#else
+#define CORR_VALUE -1 // -1 sec every ~RUNTIME_PER_SEC seconds
+#endif
+#define RUNTIME_PER_SEC (SEC_PER_MONTH / (WITH_MONTHLY_CORR * CORR_VALUE))
+volatile uint32_t corr_remaining = RUNTIME_PER_SEC;
+#endif
 
 volatile __bit S1_LONG;
 volatile __bit S1_PRESSED;
@@ -237,6 +247,10 @@ void timer0_isr() __interrupt 1 __using 1
             if (count_5000 == 5) {
                 count_5000 = 0;
                 blinker_slow = !blinker_slow;	//blink every 500ms
+#if defined(WITH_MONTHLY_CORR) && WITH_MONTHLY_CORR != 0
+                if (!blinker_slow && corr_remaining)
+                    corr_remaining --;
+#endif
 #ifndef WITHOUT_ALARM
                 // 1/ 2sec: 20000 ms
                 if (count_20000 == 20) {
@@ -704,8 +718,12 @@ int main()
 #else
                     kmode = K_NORMAL;
 #endif
-                } else if (ev == EV_S2_SHORT)
+                } else if (ev == EV_S2_SHORT) {
                     ds_sec_zero();
+#if defined(WITH_MONTHLY_CORR) && WITH_MONTHLY_CORR != 0
+                    corr_remaining = RUNTIME_PER_SEC;
+#endif
+                }
 #ifdef DEBUG
                 else if (ev == EV_S1S2_LONG)
                     kmode = K_DEBUG;
@@ -840,6 +858,13 @@ int main()
 	  else if (ss < 0x35) dmode = M_WEEKDAY_DISP;
 	  
 	}
+#endif
+
+#if defined(WITH_MONTHLY_CORR) && WITH_MONTHLY_CORR != 0
+        if (!corr_remaining && rtc_table[DS_ADDR_SECONDS] == 0x51) {
+            ds_writebyte(DS_ADDR_SECONDS, rtc_table[DS_ADDR_SECONDS] + CORR_VALUE);
+            corr_remaining = RUNTIME_PER_SEC;
+        }
 #endif
 
         switch (dmode) {

--- a/src/main.c
+++ b/src/main.c
@@ -117,7 +117,7 @@ volatile int16_t count_20000;	//2s
 volatile __bit blinker_slowest;
 #endif
 #ifndef WITHOUT_CHIME
-volatile int16_t chime_ticks;	//100ms inc
+volatile int16_t chime_ticks;   //10ms inc
 #endif
 
 volatile uint16_t count_timeout; // max 6.5536 sec
@@ -148,7 +148,7 @@ uint8_t chime_ss_bcd; // hour since
 uint8_t chime_uu_bcd; // hour until
 __bit chime_ss_pm;
 __bit chime_uu_pm;
-__bit chime_trigger = 0;
+volatile uint8_t chime_trigger = 0;
 #endif
 __bit cfg_changed = 1;
 uint8_t snooze_time;	//snooze(min)
@@ -218,6 +218,10 @@ void timer0_isr() __interrupt 1 __using 1
         count_100 = 0;
 	count_1000++;	//increment every 10ms
 
+#ifndef WITHOUT_CHIME
+        if (chime_trigger)
+            chime_ticks ++;     //increment every 10ms
+#endif
 
         // 10/sec: 100 ms
         if (count_1000 == 10) {
@@ -228,10 +232,6 @@ void timer0_isr() __interrupt 1 __using 1
 	    count_5000++;	//increment every 100ms
 #ifndef WITHOUT_ALARM
 	    count_20000++;	//increment every 100ms
-#endif
-#ifndef WITHOUT_CHIME
-        if (chime_trigger)
-            chime_ticks ++;	//increment every 100ms
 #endif
 	    // 2/sec: 500 ms
             if (count_5000 == 5) {
@@ -538,11 +538,9 @@ int main()
                 else if (uu != 0x12 && chime_uu_pm)
                     uu += 0x12;
             }
-            if((ss <= uu && hh >= ss && hh <= uu) || (ss > uu && (hh >= ss || hh <= uu))) {
-                chime_ticks = 0;
+            if((ss <= uu && hh >= ss && hh <= uu) || (ss > uu && (hh >= ss || hh <= uu)))
                 chime_trigger = 1;
             }
-        }
 #endif
 
 #ifndef WITHOUT_ALARM
@@ -1045,23 +1043,24 @@ int main()
                 BUZZER_OFF;
             }
         } else {
-#ifndef WITHOUT_CHIME
-            if (!chime_trigger)
-#endif
             BUZZER_OFF;
         }
 #endif
 
 #ifndef WITHOUT_CHIME
-        if (chime_trigger)
-            //if(chime_ticks == 0 || chime_ticks == 2)
-            if (chime_ticks == 0)
+        switch (chime_trigger) {
+        case 1: // ~100ms chime
                 BUZZER_ON;
-            //else if(chime_ticks == 1 || chime_ticks == 3)
-            else if (chime_ticks == 1 || chime_ticks == 2) // 2 times off - just in case
+            for (chime_ticks = 0; chime_ticks < 10; );
                 BUZZER_OFF;
-            else if (chime_ticks > 100) // disable after >1sec.
-                chime_trigger = 0;
+            chime_trigger = 2;
+        case 2: // wait > 1sec until rtc sec changed
+            if (chime_ticks > 150)
+                chime_trigger = 0; // stop chime
+            break;
+        default:
+            break;
+        }
 #endif
 
         __critical {


### PR DESCRIPTION
very rough time correction. if your watch is used at a relatively constant temperature and constantly goes ahead 5 seconds a month, just build with -DWITH_MONTHLY_CORR=-5 to compensate these 5 seconds. a period is calculated after which a correction of 1 second is required. not so accurate timer is used, because my STC15W404 has no enough program space to implement something like unixtime for rtc or setting adjustment value.

such a correction cannot be called precise, but it is better than nothing. it's possible to achieve decent accuracy without multiple quartz replacements.

and of course this doesn't work while running on battery/capacitor.

tested, correction works great while powered from power supply.
i'm waiting for stc15w408 to add sntp sync.